### PR TITLE
Fix activeParameter=-1 for jdtls

### DIFF
--- a/lua/cmp_nvim_lsp_signature_help/init.lua
+++ b/lua/cmp_nvim_lsp_signature_help/init.lua
@@ -99,7 +99,7 @@ source._item = function(self, signature, parameter_index)
   parameter_index = (signature.activeParameter or parameter_index or 0) + 1
 
   -- @see https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#signatureHelp
-  if #parameters < parameter_index then
+  if #parameters < parameter_index or parameter_index < 1 then
     parameter_index = 1
   end
 


### PR DESCRIPTION
eclipse.jdt.ls often returns `-1` for `activeParamer`. This seems to be in line with the LSP specs.

Current code only checks if `activeParameter` lies above the upper limit but not if its below.

Also see https://github.com/eclipse/eclipse.jdt.ls/issues/2434