### PR TITLE
Change `preselect` to false

### DIFF
--- a/lua/cmp_nvim_lsp_signature_help/init.lua
+++ b/lua/cmp_nvim_lsp_signature_help/init.lua
@@ -120,7 +120,7 @@ source._item = function(self, signature, parameter_index)
     filterText = ' ',
     insertText = self:_matchstr(label, [[\k\+]]),
     word = '',
-    preselect = true,
+    preselect = false,
     documentation = self:_docs(signature, parameter_index),
   }
 end


### PR DESCRIPTION
nvim-cmp allows configuring `<Return>` to insert a newline unless a completion has been explicitly selected, in which case it accepts the completion instead:

```
cmp.setup({
  mapping = cmp.mapping.preset.insert({
    ['<CR>'] = cmp.mapping.confirm({ select = false })
    ...
  })
  ...
})
```

This works nicely with other sources, but lsp-signature-help preselects its completion, preventing `<Return>` from inserting a newline.

For instance, `foo.endswith(<Return>` results in `foo.endswith(__suffix` instead of `foo.endswith(<CR>`.

I can't think of a good reason for preselect to be enabled.
