### PR TITLE
fix: docs not being processed by `vim.lsp.util.convert_input_to_markdown_lines`

### DIFF
--- a/lua/cmp_nvim_lsp_signature_help/init.lua
+++ b/lua/cmp_nvim_lsp_signature_help/init.lua
@@ -125,42 +125,31 @@ source._item = function(self, signature, parameter_index)
   }
 end
 
-source._docs = function(self, signature, parameter_index)
-  local documentation = {}
+source._docs = function(self, sig, idx)
+  local docs = {}
 
-  -- signature label.
-  if signature.label then
-    table.insert(documentation, self:_signature_label(signature, parameter_index))
-  end
+	-- signature label.
+	if sig.label then
+		table.insert(docs, table.concat(
+				vim.lsp.util.convert_input_to_markdown_lines(self:_signature_label(sig, idx)), "\n"))
+	end
 
-  -- parameter docs.
-  local parameter = signature.parameters[parameter_index]
-  if parameter then
-    if parameter.documentation then
-      table.insert(documentation, '---')
-      if type(parameter.documentation) == 'table' then
-        table.insert(documentation, '```' .. parameter.documentation.kind)
-        table.insert(documentation, parameter.documentation.value)
-        table.insert(documentation, '```')
-      else
-        table.insert(documentation, parameter.documentation)
-      end
-    end
-  end
+	-- parameter docs.
+	local parameter = sig.parameters[idx]
+	if parameter then
+		if parameter.documentation then
+			table.insert(docs, table.concat(
+					vim.lsp.util.convert_input_to_markdown_lines(parameter.documentation), "\n"))
+		end
+	end
 
-  -- signature docs.
-  if signature.documentation then
-    table.insert(documentation, '---')
-    if type(signature.documentation) == 'table' then
-      table.insert(documentation, '```' .. signature.documentation.kind)
-      table.insert(documentation, signature.documentation.value)
-      table.insert(documentation, '```')
-    else
-      table.insert(documentation, signature.documentation)
-    end
-  end
+	-- signature docs.
+	if sig.documentation then
+		table.insert(docs,
+				table.concat(vim.lsp.util.convert_input_to_markdown_lines(sig.documentation), "\n"))
+	end
 
-  return { kind = 'markdown', value = table.concat(documentation, '\n') }
+	return {kind = 'markdown', value = table.concat(docs, '\n\n')}
 end
 
 source._signature_label = function(self, signature, parameter_index)


### PR DESCRIPTION
Normally, the documentation goes through neovim's inbuilt method to process used markdown with a centralized function. This function by default does basically the same as the original code, but when some other plugin takes on the chore to give a better representation of documentation markdown (noice.nvim or reform.nvim), it shouldn't have to replace every plugin's markdown processing, because they should use the inbuilt method first.