### PR TITLE
Improve active parameter highlighting

### DIFF
--- a/lua/cmp_nvim_lsp_signature_help/init.lua
+++ b/lua/cmp_nvim_lsp_signature_help/init.lua
@@ -169,7 +169,7 @@ source._signature_label = function(self, signature, parameter_index)
     local s, e = string.find(label, self:_parameter_label(signature, signature.parameters[parameter_index]), 1, true)
     if s and e then
       local active = string.sub(label, s, e)
-      label = string.gsub(label, vim.pesc(active), '***' .. active .. '***')
+      label = string.gsub(label, vim.pesc(active), "`" .. active .. "`")
     end
   end
   return label


### PR DESCRIPTION
This is a kickoff to implement the feature requested on #30.

Note: although this PR already delivers the intended feature, it would be very nice to make this plugin override `vim.lsp.buf.signature_help()` with a formatted signature help and proper parameter highlighting. Unfortunately though, that's beyond my knowledge.