### PR TITLE
feat: allow multiline arg passing

### DIFF
--- a/lua/cmp_nvim_lsp_signature_help/init.lua
+++ b/lua/cmp_nvim_lsp_signature_help/init.lua
@@ -181,7 +181,7 @@ source._parameter_label = function(_, signature, parameter)
 end
 
 source._get_client = function(self)
-  for _, client in pairs(vim.lsp.buf_get_clients()) do
+  for _, client in pairs(vim.lsp.get_clients({bufnr = 0})) do
     if self:_get(client.server_capabilities, { 'signatureHelpProvider' }) then
       return client
     end

--- a/lua/cmp_nvim_lsp_signature_help/init.lua
+++ b/lua/cmp_nvim_lsp_signature_help/init.lua
@@ -32,13 +32,7 @@ end
 
 source.complete = function(self, params, callback)
   local client = self:_get_client()
-  local trigger_characters = {}
-  for _, c in ipairs(self:_get(client.server_capabilities, { 'signatureHelpProvider', 'triggerCharacters' }) or {}) do
-    table.insert(trigger_characters, c)
-  end
-  for _, c in ipairs(self:_get(client.server_capabilities, { 'signatureHelpProvider', 'retriggerCharacters' }) or {}) do
-    table.insert(trigger_characters, c)
-  end
+  local trigger_characters = self:get_trigger_characters()
 
   local trigger_character = nil
   for _, c in ipairs(trigger_characters) do


### PR DESCRIPTION
By reusing `get_trigger_characters()`, we can now trigger signature completion on multiline.  
Only difference with before is that it adds a blank space in the list of trigger characters.

Useful when doing stuff like:
```python
my_func(
    arg0,
    arg1,
    ...
)
```

Only drawback is that we will make `signatureHelp` LSP requests a bit more often I guess?