### PR TITLE
Fix: Usage of deprecated vim.lsp.buf_get_clients

### DIFF
--- a/lua/cmp_nvim_lsp_signature_help/init.lua
+++ b/lua/cmp_nvim_lsp_signature_help/init.lua
@@ -187,7 +187,8 @@ source._parameter_label = function(_, signature, parameter)
 end
 
 source._get_client = function(self)
-  for _, client in pairs(vim.lsp.buf_get_clients()) do
+  local get_clients = vim.lsp.get_clients or vim.lsp.buf_get_clients
+  for _, client in pairs(get_clients()) do
     if self:_get(client.server_capabilities, { 'signatureHelpProvider' }) then
       return client
     end


### PR DESCRIPTION
We should be using vim.lsp.get_clients() instead.