### PR TITLE
fix: use only clients attached to current buffer

### DIFF
--- a/lua/cmp_nvim_lsp_signature_help/init.lua
+++ b/lua/cmp_nvim_lsp_signature_help/init.lua
@@ -187,7 +187,9 @@ source._parameter_label = function(_, signature, parameter)
 end
 
 source._get_client = function(self)
-  local get_clients = vim.lsp.get_clients or vim.lsp.buf_get_clients
+  local get_clients = function()
+    return vim.lsp.get_clients({ bufnr = 0 })
+  end or vim.lsp.buf_get_clients
   for _, client in pairs(get_clients()) do
     if self:_get(client.server_capabilities, { 'signatureHelpProvider' }) then
       return client


### PR DESCRIPTION
`vim.lsp.get_clients` works only as a replacement for `vim.lsp.buf_get_clients` when explicitly told to get clients for the current buffer. Otherwise all clients attached to any buffer are returned.