### PR TITLE
Properly normalize vim.NIL values.

### DIFF
--- a/lua/cmp_nvim_lsp_signature_help/init.lua
+++ b/lua/cmp_nvim_lsp_signature_help/init.lua
@@ -96,7 +96,9 @@ source._item = function(self, signature, parameter_index)
     return nil
   end
 
-  parameter_index = (signature.activeParameter or parameter_index or 0) + 1
+  local ap = signature.activeParameter ~= vim.NIL and signature.activeParameter or nil
+  parameter_index = parameter_index ~= vim.NIL and parameter_index or nil
+  parameter_index = (ap or parameter_index or 0) + 1
 
   -- @see https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#signatureHelp
   if #parameters < parameter_index or parameter_index < 1 then


### PR DESCRIPTION
Fixes #57. 
If `signature.activeParameter` and `parameter_index` are equal to `vim.NIL`, they are converted to `nil` before trying to increment.