### PR TITLE
Check signature_help.signatures is of type 'table'

### DIFF
--- a/lua/cmp_nvim_lsp_signature_help/init.lua
+++ b/lua/cmp_nvim_lsp_signature_help/init.lua
@@ -75,7 +75,7 @@ source.complete = function(self, params, callback)
 end
 
 source._items = function(self, signature_help)
-  if not signature_help or not signature_help.signatures then
+  if not signature_help or type(signature_help.signatures) ~= 'table' then
     return {}
   end
 


### PR DESCRIPTION
signature_help.signatures may be vim.NIL, which is truthy and is accepted by the current check.
If the LSP returns vim.NIL, the following
error will be the result:

vim.schedule callback: ...-signature-help/lua/cmp_nvim_lsp_signature_help/init.lua:87: bad argument #1 to 'ipairs' (table expected, got userdata) stack traceback:
        [C]: in function 'ipairs'
        ...-signature-help/lua/cmp_nvim_lsp_signature_help/init.lua:87: in function '_items'
        ...-signature-help/lua/cmp_nvim_lsp_signature_help/init.lua:72: in function 'handler'
        /usr/local/share/nvim/runtime/lua/vim/lsp/client.lua:742: in function ''
        vim/_core/editor.lua: in function <vim/_core/editor.lua:0>